### PR TITLE
Allow waiting single interface

### DIFF
--- a/meta-core/classes/nfs42-mount.bbclass
+++ b/meta-core/classes/nfs42-mount.bbclass
@@ -18,6 +18,9 @@ python () {
 
 NFS_MOUNT_DESCRIPTION ??= "NFS remote directory"
 
+# Keep empty to wait for all interfaces to be ready
+NFS_WAITING_INTERFACE ?= ""
+
 SYSTEMD_SERVICE:${PN} = "${NFS_MOUNT_NAME}.mount"
 SYSTEMD_SERVICE:${PN}-auto = "${NFS_MOUNT_NAME}.automount"
 
@@ -29,11 +32,14 @@ do_install:append () {
     install -d ${D}${NFS_MOUNT_MOUNTPOINT}
     install -d ${D}${systemd_system_unitdir}
 
+    wait_interface=
+    [ -z "${NFS_WAITING_INTERFACE}" ] || wait_interface="@${NFS_WAITING_INTERFACE}"
+
     cat <<EOF >${D}${systemd_system_unitdir}/${NFS_MOUNT_NAME}.mount
 [Unit]
 Description=Mount ${NFS_MOUNT_DESCRIPTION}
-Requires=systemd-networkd-wait-online.service
-After=systemd-networkd-wait-online.service
+Requires=systemd-networkd-wait-online$wait_interface.service
+After=systemd-networkd-wait-online$wait_interface.service
 
 [Mount]
 What=${NFS_MOUNT_REMOTE}


### PR DESCRIPTION
Some systems may have network interfaces which never get up. This would prevent the process from starting. This patch allows to specify a single interface to wait for.
If NFS_WAITING_INTERFACE is specified, this is the only interface the process will wait for before trying to mount NFS drive. If the variable is kept empty (default value), then the default behavior will be the same as today, i.e. waiting for all interfaces to be ready.